### PR TITLE
mongo cache should be first checked

### DIFF
--- a/tkpweb/apps/dataset/tools/plot.py
+++ b/tkpweb/apps/dataset/tools/plot.py
@@ -67,10 +67,10 @@ class ImagePlot(Plot):
 
     def plot(self, dbimage, scale=0.9, plotsources=None, database=None):
         try:
-            if os.path.exists(dbimage['url']):
-                hdu = pyfits.open(dbimage['url'], readonly=True)
-            elif MONGODB["enabled"]:
+            if MONGODB["enabled"]:
                 hdu = fetch_hdu_from_mongo(dbimage['url'])
+            elif os.path.exists(dbimage['url']):
+                hdu = pyfits.open(dbimage['url'], readonly=True)
             else:
                 raise Exception("FITS file not available")
         except Exception, e:


### PR DESCRIPTION
for example on my system, a casafolder would exists, but this can't be handled by pyfits! 
