### PR TITLE
List filenames on the 'images' listing page.

### DIFF
--- a/tkpweb/apps/dataset/templates/dataset/images.html
+++ b/tkpweb/apps/dataset/templates/dataset/images.html
@@ -17,6 +17,7 @@
 <th><a href="{% url 'dataset:images' dataset=dataset.id %}?order={% if ordering.0 == 'process_ts' and ordering.1 == 'ASC' %}-{% endif %}process_ts">Bandwidth (MHz.)</a></th>
 <th>Number of sources in image</th>
     <th><a href="{% url 'dataset:images' dataset=dataset.id %}?order={% if ordering.0 == 'reject' and ordering.1 == 'ASC' %}-{% endif %}reject">Quality Rejection</a></th>
+<th>Filename</th>
 </tr>
 </thead>
 <tbody>
@@ -35,6 +36,7 @@
 <td>{{ image.freq_bw|prefixformat:"M"|stringformat:".3f"  }}</td>
 <td>{{ image.ntotalsources }}</td>
 <td>{{ image.reject }}</td>
+<td>{{ image.url|basename_format }}</td>
 </tr>
 {% endfor %}
 </tbody>

--- a/tkpweb/apps/dataset/templatetags/formatting.py
+++ b/tkpweb/apps/dataset/templatetags/formatting.py
@@ -2,6 +2,7 @@ from django import template
 from django.utils.safestring import mark_safe
 from tkp.utility.coordinates import (ratohms, dectodms)
 register = template.Library()
+import os
 
 
 @register.filter
@@ -27,3 +28,8 @@ def format_angle(value, format_type):
             sign = '-'
         result = "%s%d:%d:%.1f" % (sign, d, m, s)
     return mark_safe(result)
+
+@register.filter
+def basename_format(value):
+    """Returns just the basename from a URL"""
+    return os.path.basename(value)


### PR DESCRIPTION
This is useful when tracking down a problematic image, to test new code.
