### PR TITLE
iss4234, explicit join on image.dataset in transients query

### DIFF
--- a/tkpweb/apps/dataset/tools/dbase.py
+++ b/tkpweb/apps/dataset/tools/dbase.py
@@ -220,7 +220,8 @@ SELECT COUNT(*) FROM extractedsource WHERE image = %s"""
                        AND t.runcat = rc.id
                        AND t.trigger_xtrsrc = x.id
                        AND x.image = i.id
-                    """, id, dataset)
+                       AND i.dataset = %s
+                    """, id, dataset, dataset)
             else:
                 self.db.execute("""\
                     SELECT transient.*
@@ -259,7 +260,8 @@ SELECT COUNT(*) FROM extractedsource WHERE image = %s"""
                        AND t.runcat = rc.id
                        AND t.trigger_xtrsrc = x.id
                        AND x.image = i.id
-                    """, dataset)
+                       AND i.dataset = %s
+                    """, dataset, dataset)
             else:
                 self.db.execute("""\
                     SELECT transient.*


### PR DESCRIPTION
This should solve the long-waiting case for clicking the link to show all transients found for a particular dataset and the number is large (>10000 transients).
