### PR TITLE
Fix thumbnail generation

### DIFF
--- a/tkpweb/apps/dataset/tools/mongo.py
+++ b/tkpweb/apps/dataset/tools/mongo.py
@@ -2,6 +2,8 @@ from tkpweb.settings import MONGODB
 from pymongo import Connection
 from gridfs import GridFS
 from contextlib import closing
+from tempfile import mkstemp
+from os import fdopen
 import pyfits
 
 def fetch_hdu_from_mongo(filename):
@@ -11,3 +13,13 @@ def fetch_hdu_from_mongo(filename):
         ) as mongo_connection:
             gfs = GridFS(mongo_connection[MONGODB["database"]])
             return pyfits.open(gfs.get_version(filename), mode="readonly")
+
+def fetch_file_from_mongo(filename):
+    if MONGODB["enabled"]:
+        handle, tempfilename = mkstemp()
+        with fdopen(handle, "w") as output, closing(
+            Connection(host=MONGODB["host"], port=MONGODB["port"])
+        ) as mongo_connection:
+            gfs = GridFS(mongo_connection[MONGODB["database"]])
+            output.write(gfs.get_version(filename).read())
+        return tempfilename

--- a/tkpweb/apps/dataset/tools/plot.py
+++ b/tkpweb/apps/dataset/tools/plot.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import StringIO
 import base64
 import datetime
@@ -17,6 +17,7 @@ from tkp.utility import accessors
 from tkpweb.settings import MONGODB
 if MONGODB["enabled"]:
     from .mongo import fetch_hdu_from_mongo
+    from .mongo import fetch_file_from_mongo
 
 
 class Plot(object):
@@ -103,8 +104,8 @@ class ThumbnailPlot(Plot):
             elif os.path.exists(filename):
                 image = accessors.FitsImage(filename)
             elif MONGODB["enabled"]:
-                hdu = fetch_hdu_from_mongo(filename)
-                image = accessors.FitsImage(hdu)
+                fits = fetch_file_from_mongo(filename)
+                image = accessors.FitsImage(fits)
             else:
                 raise Exception("Image file not available")
         except Exception, e:
@@ -131,6 +132,10 @@ class ThumbnailPlot(Plot):
         if thumbnail.any():
             axes.imshow(thumbnail)
             self.figure.subplots_adjust(bottom=0, left=0, top=1, right=1)
+
+        # If we created a temporary file, better clean it up
+        if "fits" in locals():
+            os.unlink(fits)
 
 
 class LightcurvePlot(Plot):


### PR DESCRIPTION
Since changes to the TKP accessors mean we can no longer directly use an HDU
from MongoDB, we rather write a temporary fits file and generate the thumbnail
based on that.

Addresses #4316.
