### PR TITLE
Autocommit=True for read-only queries.

### DIFF
--- a/tkp.cfg_template
+++ b/tkp.cfg_template
@@ -5,4 +5,6 @@ name =
 user = 
 password = 
 port = 
-autocommit = False
+# For read-only queries autocommit must be switched to on.
+# Do not change it.
+autocommit = True


### PR DESCRIPTION
TKP-web is a read-only app. Autocommit must be switched to on, otherwise
all queries will start in a transaction which is not committed by the code.
This caused the sql_logs files to continuously growing, since multiple
transactions were active.
